### PR TITLE
clean license warnings | fix explicit conversion for solc 0.8.1

### DIFF
--- a/src/auth.sol
+++ b/src/auth.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GNU-3
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
@@ -28,7 +29,7 @@ contract DSAuth is DSAuthEvents {
     DSAuthority  public  authority;
     address      public  owner;
 
-    constructor() public {
+    constructor() {
         owner = msg.sender;
         emit LogSetOwner(msg.sender);
     }
@@ -59,7 +60,7 @@ contract DSAuth is DSAuthEvents {
             return true;
         } else if (src == owner) {
             return true;
-        } else if (authority == DSAuthority(0)) {
+        } else if (authority == DSAuthority(address(0))) {
             return false;
         } else {
             return authority.canCall(src, address(this), sig);

--- a/src/auth.t.sol
+++ b/src/auth.t.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GNU-3
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
@@ -24,7 +25,7 @@ contract FakeVault is DSAuth {
 contract BooleanAuthority {
     bool yes;
 
-    constructor(bool _yes) public {
+    constructor(bool _yes) {
         yes = _yes;
     }
 


### PR DESCRIPTION
- add GNU-3 license tags
- fix address to have explicit conversion
- clean 'public' from constructors, to clean 0.8.1 warnings [once they are ignored anyway]